### PR TITLE
Hotfix for the scrapView reusage

### DIFF
--- a/src/com/huewu/pla/lib/internal/PLA_AbsListView.java
+++ b/src/com/huewu/pla/lib/internal/PLA_AbsListView.java
@@ -2734,6 +2734,8 @@ ViewTreeObserver.OnGlobalLayoutListener, ViewTreeObserver.OnTouchModeChangeListe
 		})
 		public int viewType;
 
+		public int scrappedFromPosition;
+		
 		/**
 		 * When this boolean is set, the view has been added to the AbsListView
 		 * at least once. It is used to know whether headers/footers have already
@@ -2948,6 +2950,17 @@ ViewTreeObserver.OnGlobalLayoutListener, ViewTreeObserver.OnTouchModeChangeListe
 				if (whichScrap >= 0 && whichScrap < mScrapViews.length) {
 					scrapViews = mScrapViews[whichScrap];
 					int size = scrapViews.size();
+					
+					// look for the exact same layout
+					LayoutParams lp;
+					for(int i = 0; i < size; i++) {
+						lp = (LayoutParams) scrapViews.get(i).getLayoutParams();
+						if(lp.scrappedFromPosition == position) {
+							return scrapViews.remove(i);
+						}
+					}
+					
+					// return the last scrapView
 					if (size > 0) {
 						return scrapViews.remove(size - 1);
 					}

--- a/src/com/huewu/pla/lib/internal/PLA_ListView.java
+++ b/src/com/huewu/pla/lib/internal/PLA_ListView.java
@@ -1363,6 +1363,7 @@ public class PLA_ListView extends PLA_AbsListView {
 					ViewGroup.LayoutParams.WRAP_CONTENT, 0);
 		}
 		p.viewType = mAdapter.getItemViewType(position);
+		p.scrappedFromPosition = position;
 
 		if ((recycled && !p.forceAdd) || (p.recycledHeaderFooter &&
 				p.viewType == PLA_AdapterView.ITEM_VIEW_TYPE_HEADER_OR_FOOTER)) {


### PR DESCRIPTION
- added scrappedFromPosition (like in the android ListView implementation) to associate listpositions with scrapViews -> should fix https://github.com/huewu/PinterestLikeAdapterView/issues/8
